### PR TITLE
fix import path for esxi_netinit and re-enable automating gdisk execution

### DIFF
--- a/src/esxi_img/cmd.py
+++ b/src/esxi_img/cmd.py
@@ -15,7 +15,7 @@ import tarfile
 import tempfile
 from pathlib import Path
 
-import netinit
+import esxi_netinit
 import pycdlib
 
 import esxi_img
@@ -130,7 +130,7 @@ def generate_installer_helper(ks_template_path: str | None, output_path: str) ->
                         tar.addfile(tar_info, f)
 
             # add in netinit
-            netinit_files = importlib.resources.files(netinit)
+            netinit_files = importlib.resources.files(esxi_netinit)
             for entry in netinit_files.iterdir():
                 if entry.stem in ["__pycache__", ".", ".."]:
                     continue

--- a/src/esxi_img/cmd.py
+++ b/src/esxi_img/cmd.py
@@ -370,12 +370,11 @@ def _create_vmdk_macos(source_dir: Path, image_path: str, size_mb: int) -> int:
             "y",
         ]
 
-        logger.info("You must run the following afterwards: gdisk %s", image_path)
-        logger.info("And use the following commands: %s", gdisk_cmds)
-
-        # gdisk_input = "\n".join(gdisk_cmds)
-        # subprocess.run(["gdisk", str(img_dmg_path)], input=gdisk_input,
-        #                check=True, text=True)
+        # each command followed by [Enter]
+        gdisk_input = "\n".join(gdisk_cmds) + "\n"
+        subprocess.run(
+            ["gdisk", str(img_dmg_path)], input=gdisk_input, check=True, text=True
+        )
 
     finally:
         # Step 8: Detach the disk image


### PR DESCRIPTION
Fixed up the import path for esxi_netinit now that things are proper packages. Re-enable the automatic execution of `gdisk` after @skrobul pointed out I was missing the enter after the last command.