### PR TITLE
Make multi-network configs work correctly

### DIFF
--- a/packages/esxi-netinit/esxi_netinit/esxconfig.py
+++ b/packages/esxi-netinit/esxi_netinit/esxconfig.py
@@ -1,8 +1,10 @@
 import logging
 from functools import cached_property
+from ipaddress import ip_network
 
 from .esxhost import ESXHost
 from .meta_data import MetaDataData
+from .network import Network
 from .network_data import NetworkData
 from .nic import NIC
 from .nic_list import NICList
@@ -18,6 +20,8 @@ class ESXConfig:
         self.meta_data = meta_data
         self.dry_run = dry_run
         self.host = ESXHost(dry_run)
+        self.uplink_map = {}
+        self.next_switch_number = 31
 
     def configure_hostname(self):
         self.host.set_hostname(self.meta_data.metadata.hostname)
@@ -30,52 +34,63 @@ class ESXConfig:
         )
         self.host.destroy_vswitch(name=switch_name)
 
-    def configure_portgroups(self, switch_name: str, portgroups):
-        """Adds each requested portgroup to the specified switch."""
-        for portgroup_name in portgroups:
-            self.host.portgroup_add(portgroup_name, switch_name)
-
     def configure_default_route(self):
         """Configures default route.
 
         If multiple default routes are present, only first one is used.
         """
         route = self.network_data.default_route()
-        self.host.configure_default_route(route.gateway)
+        self.host.configure_static_route(route.gateway, "default")
 
-    def configure_vlans(self, switch_name="vSwitch0"):
-        portgroups = []
-        for link in self.network_data.links:
-            if link.type == "vlan":
-                vid = link.vlan_id
-                pg_name = f"internal_net_vid_{vid}"
-                self.host.portgroup_add(portgroup_name=pg_name, switch_name=switch_name)
-                self.host.portgroup_set_vlan(portgroup_name=pg_name, vlan_id=vid)
-                portgroups.append(pg_name)
-        return portgroups
-
-    def configure_management_interface(self, mgmt_portgroup: str):
+    def configure_static_routes(self):
+        """Configures any static routes in the config"""
         for net in self.network_data.networks:
-            logger.info(
-                "Creating %s with MAC %s for network %s",
-                net.id,
-                net.link.ethernet_mac_address,
-                net.network_id,
-            )
-            self.host.add_ip_interface(
-                net.id, mgmt_portgroup, net.link.ethernet_mac_address, net.link.mtu
-            )
-            if net.type == "ipv4":
-                self.host.set_static_ipv4(net.id, net.ip_address, net.netmask)
-            elif net.type == "ipv4_dhcp":
-                self.host.set_dhcp_ipv4(net.id)
+            for route in [r for r in net.routes if not r.is_default()]:
+                route_net = ip_network(f"{route.network}/{route.netmask}")
+                self.host.configure_static_route(route.gateway, route_net.compressed)
+
+    def get_next_vswitch(self):
+        switch_name = f"vSwitch{self.next_switch_number}"
+        self.next_switch_number += 1
+        return switch_name
+
+    def configure_interface(self, net: Network, switch_name=None, portgroup_name=None):
+        uplinks = self.identify_uplinks(net)
+        if not uplinks:
+            raise ValueError(f"No uplinks identified for network ID {net.network_id}")
+        uplink_set = frozenset(u.name for u in uplinks)
+        if uplink_set not in self.uplink_map:
+            switch_name = switch_name or self.get_next_vswitch()
+            self.configure_vswitch(switch_name, mtu=net.link.mtu, uplinks=uplinks)
+            self.uplink_map[uplink_set] = switch_name
+        else:
+            switch_name = self.uplink_map[uplink_set]
+
+        if not portgroup_name:
+            if net.link.type == "vlan":
+                portgroup_name = f"internal_net_vid_{net.link.vlan_id}"
             else:
-                raise NotImplementedError(f"net type {net.type}")
+                portgroup_name = net.link.id
+        self.host.portgroup_add(portgroup_name, switch_name)
+        if net.link.type == "vlan":
+            self.host.portgroup_set_vlan(portgroup_name, net.link.vlan_id)
 
-    def configure_vswitch(self, switch_name: str, mtu: int):
+        mac = (
+            "auto" if net.link.type == "vlan" else net.link.ethernet_mac_address.lower()
+        )
+        logger.info(f"Creating {net.id} with MAC {mac} for network {net.network_id}")
+        self.host.add_ip_interface(net.id, portgroup_name, mac, net.link.mtu)
+
+        if net.type == "ipv4":
+            self.host.set_static_ipv4(net.id, net.ip_address, net.netmask)
+        elif net.type == "ipv4_dhcp":
+            self.host.set_dhcp_ipv4(net.id)
+        else:
+            raise NotImplementedError(f"net type {net.type}")
+
+    def configure_vswitch(self, switch_name: str, mtu: int, uplinks: list[NIC]):
         """Sets up vSwitch."""
-        uplinks: list[NIC] = self.identify_uplinks()
-
+        logger.info(f"Creating vswitch {switch_name} with uplinks {uplinks}")
         self.host.create_vswitch(switch_name)
         for uplink in uplinks:
             self.host.uplink_add(nic=uplink.name, switch_name=switch_name)
@@ -97,16 +112,39 @@ class ESXConfig:
 
         return self.host.configure_dns(servers=dns_servers)
 
-    def identify_uplinks(self) -> list[NIC]:
-        eligible_networks = [
-            net for net in self.network_data.networks if net.default_routes()
-        ]
+    def identify_uplinks(self, net: Network) -> list[NIC]:
+        # Right now, a network can only refer to a single link, which will be either
+        # a vlan (that then refers to an underlying link), or a direct link.
+        # If at some point a new link type is defined that ties together multiple
+        # underlying links in a team, that could result in multiple uplinks being
+        # available to a network. Until then, there can only be a single result.
+        if net.link.vlan_link:
+            links = [net.link.vlan_link]
+        else:
+            links = [net.link]
 
-        return [
-            self.nics.find_by_mac(n.link.ethernet_mac_address)
-            for n in eligible_networks
-        ]
+        return [self.nics.find_by_mac(l.ethernet_mac_address) for l in links]
 
     @cached_property
     def nics(self):
         return NICList()
+
+    @cached_property
+    def management_network(self) -> Network:
+        """Returns the first network with a default route defined, or the first
+        network if no networks have a default route"""
+        try:
+            return next(
+                (net for net in self.network_data.networks if net.default_routes()),
+                next(iter(self.network_data.networks)),
+            )
+        except StopIteration:
+            raise Exception("No candidate found for management network")
+
+    @cached_property
+    def other_networks(self) -> list[Network]:
+        return [
+            net
+            for net in self.network_data.networks
+            if net.id != self.management_network.id
+        ]

--- a/packages/esxi-netinit/esxi_netinit/esxhost.py
+++ b/packages/esxi-netinit/esxi_netinit/esxhost.py
@@ -34,25 +34,28 @@ class ESXHost:
         logger.info(
             "Adding IP interface %s (%s) for portgroup %s", inf, mac, portgroup_name
         )
-        return self.__execute(
+        cmd = [
+            "/bin/esxcli",
+            "network",
+            "ip",
+            "interface",
+            "add",
+            "--interface-name",
+            inf,
+        ]
+        if mac != "auto":
+            cmd.extend(["--mac-address", mac])
+        cmd.extend(
             [
-                "/bin/esxcli",
-                "network",
-                "ip",
-                "interface",
-                "add",
-                "--interface-name",
-                inf,
-                "--mac-address",
-                mac,
                 "--mtu",
                 str(mtu),
                 "--portgroup-name",
                 portgroup_name,
             ]
         )
+        return self.__execute(cmd)
 
-    def configure_default_route(self, gateway):
+    def configure_static_route(self, gateway, network):
         cmd = [
             "/bin/esxcli",
             "network",
@@ -63,7 +66,7 @@ class ESXHost:
             "-g",
             gateway,
             "-n",
-            "default",
+            network,
         ]
         return self.__execute(cmd)
 

--- a/packages/esxi-netinit/esxi_netinit/main.py
+++ b/packages/esxi-netinit/esxi_netinit/main.py
@@ -59,14 +59,18 @@ def main(config_dir, dry_run):
     esx = ESXConfig(network_data, meta_data, dry_run=dry_run)
     esx.configure_hostname()
     esx.clean_default_network_setup(OLD_MGMT_PG, OLD_VSWITCH)
-    esx.configure_vswitch(switch_name=NEW_VSWITCH, mtu=9000)
 
     # this configures the Management Network to the default vSwitch
-    esx.configure_portgroups(NEW_VSWITCH, [NEW_MGMT_PG])
-    esx.configure_vlans()
-    esx.configure_management_interface(NEW_MGMT_PG)
+    esx.configure_interface(esx.management_network, NEW_VSWITCH, NEW_MGMT_PG)
     esx.configure_default_route()
     esx.configure_requested_dns()
+
+    # this configures the remaining networks, adding more vSwitches as necessary
+    for net in esx.other_networks:
+        esx.configure_interface(net)
+
+    # Finally add any static routes
+    esx.configure_static_routes()
 
 
 if __name__ == "__main__":

--- a/packages/esxi-netinit/esxi_netinit/nic_list.py
+++ b/packages/esxi-netinit/esxi_netinit/nic_list.py
@@ -32,6 +32,6 @@ class NICList(list):
 
     def find_by_mac(self, mac) -> NIC:
         try:
-            return next(nic for nic in self if nic.mac == mac)
+            return next(nic for nic in self if nic.mac.lower() == mac.lower())
         except StopIteration:
             raise ValueError(f"No NIC with MAC {mac}") from None

--- a/packages/esxi-netinit/tests/conftest.py
+++ b/packages/esxi-netinit/tests/conftest.py
@@ -17,8 +17,13 @@ def network_data_single():
 
 
 @pytest.fixture
-def network_data_multi():
-    return _load_json(THIS_DIR / "data" / "net_data_multi.json")
+def network_data_multi_phy():
+    return _load_json(THIS_DIR / "data" / "net_data_multi_phy.json")
+
+
+@pytest.fixture
+def network_data_multi_vlan():
+    return _load_json(THIS_DIR / "data" / "net_data_multi_vlan.json")
 
 
 @pytest.fixture

--- a/packages/esxi-netinit/tests/data/net_data_multi_phy.json
+++ b/packages/esxi-netinit/tests/data/net_data_multi_phy.json
@@ -1,0 +1,92 @@
+{
+  "links": [
+    {
+      "id": "tapbb0c9df9-fd",
+      "vif_id": "bb0c9df9-fd9d-4f72-b3dc-485b8ad79bdd",
+      "type": "phy",
+      "mtu": 9000,
+      "ethernet_mac_address": "d4:04:e6:4f:a4:d6"
+    },
+    {
+      "id": "tap-stor-100",
+      "vif_id": "54ee92fc-ac01-411e-99a9-eea240e921a7",
+      "type": "phy",
+      "mtu": 9000,
+      "ethernet_mac_address": "D4:04:E6:4F:A4:D7"
+    },
+    {
+      "id": "tap-stor-101",
+      "vif_id": "d87696f3-b4e8-4266-a1bd-6c5beb860470",
+      "type": "phy",
+      "mtu": 9000,
+      "ethernet_mac_address": "14:23:F3:F6:D8:21"
+    }
+  ],
+  "networks": [
+    {
+      "id": "network0",
+      "type": "ipv4",
+      "link": "tapbb0c9df9-fd",
+      "ip_address": "172.31.31.7",
+      "netmask": "255.255.255.0",
+      "routes": [
+        {
+          "network": "0.0.0.0",
+          "netmask": "0.0.0.0",
+          "gateway": "172.31.31.1"
+        }
+      ],
+      "network_id": "77729327-9df3-4ae4-b077-5a3c069abff4",
+      "services": [
+        {
+          "type": "dns",
+          "address": "10.8.255.164"
+        },
+        {
+          "type": "dns",
+          "address": "10.8.255.165"
+        }
+      ]
+    },
+    {
+      "id": "network-for-if100",
+      "type": "ipv4",
+      "link": "tap-stor-100",
+      "ip_address": "100.126.64.6",
+      "netmask": "255.255.255.252",
+      "routes": [
+        {
+          "network": "100.127.0.0",
+          "netmask": "255.255.128.0",
+          "gateway": "100.126.64.5"
+        }
+      ],
+      "network_id": "605e6320b68f46bfb30cdf50c9e2d884"
+    },
+    {
+      "id": "network-for-if101",
+      "type": "ipv4",
+      "link": "tap-stor-101",
+      "ip_address": "100.126.192.6",
+      "netmask": "255.255.255.252",
+      "routes": [
+        {
+          "network": "100.127.128.0",
+          "netmask": "255.255.128.0",
+          "gateway": "100.126.192.5"
+        }
+      ],
+      "network_id": "1ff2fc017a5746b7b6192096307e97f7"
+    }
+  ],
+  "services": [
+    {
+      "type": "dns",
+      "address": "10.8.255.164"
+    },
+    {
+      "type": "dns",
+      "address": "10.8.255.165"
+    }
+  ]
+}

--- a/packages/esxi-netinit/tests/data/net_data_multi_vlan.json
+++ b/packages/esxi-netinit/tests/data/net_data_multi_vlan.json
@@ -8,6 +8,13 @@
       "ethernet_mac_address": "14:23:f3:f5:3a:d0"
     },
     {
+      "id": "tapbb0c9df9-fd",
+      "vif_id": "bb0c9df9-fd9d-4f72-b3dc-485b8ad79bdd",
+      "type": "phy",
+      "mtu": 9000,
+      "ethernet_mac_address": "d4:04:e6:4f:a4:d6"
+    },
+    {
       "id": "tap1b9c25a9-39",
       "vif_id": "1b9c25a9-396f-43e7-9f1c-a2dcdfd3989c",
       "type": "vlan",
@@ -23,7 +30,7 @@
       "type": "vlan",
       "mtu": 1450,
       "ethernet_mac_address": "fa:16:3e:31:50:d6",
-      "vlan_link": "tap47bb4c37-f6",
+      "vlan_link": "tapbb0c9df9-fd",
       "vlan_id": 222,
       "vlan_mac_address": "fa:16:3e:31:50:d6"
     },
@@ -61,7 +68,13 @@
       "link": "tap1b9c25a9-39",
       "ip_address": "192.168.200.174",
       "netmask": "255.255.255.0",
-      "routes": [],
+      "routes": [
+        {
+          "network": "0.0.0.0",
+          "netmask": "0.0.0.0",
+          "gateway": "192.168.200.1"
+        }
+      ],
       "network_id": "9608ea7d-18d9-4298-8951-ac9dbe20db06",
       "services": []
     },

--- a/packages/esxi-netinit/tests/test_esxconfig.py
+++ b/packages/esxi-netinit/tests/test_esxconfig.py
@@ -28,17 +28,23 @@ def test_configure_default_route(network_data_single, meta_data, host_mock):
     ec = ESXConfig(ndata, meta_data, dry_run=False)
     ec.host = host_mock
     ec.configure_default_route()
-    host_mock.configure_default_route.assert_called_once_with("192.168.1.1")
+    host_mock.configure_static_route.assert_called_once_with("192.168.1.1", "default")
 
 
-def test_configure_management_interface(network_data_single, meta_data, host_mock):
+def test_configure_management_interface(
+    network_data_single, meta_data, host_mock, mocker
+):
     ndata = NetworkData(network_data_single)
     meta_data = MetaDataData(meta_data)
     ec = ESXConfig(ndata, meta_data, dry_run=False)
     ec.host = host_mock
+    nic = NIC(name="vmnic0", status="Up", link="Up", mac="14:23:f3:f5:3a:d0")
+    mocker.patch.object(ec, "identify_uplinks", return_value=[nic])
     mgmt_pg = "Management Network"
     mgmt_net = ndata.networks[0]
-    ec.configure_management_interface(mgmt_pg)
+    ec.configure_interface(ec.management_network, "vSwitch11", mgmt_pg)
+    host_mock.create_vswitch.assert_called_once_with("vSwitch11")
+    host_mock.portgroup_add.assert_called_once_with("Management Network", "vSwitch11")
     host_mock.add_ip_interface.assert_called_once_with(
         mgmt_net.id, mgmt_pg, mgmt_net.link.ethernet_mac_address, mgmt_net.link.mtu
     )
@@ -47,17 +53,156 @@ def test_configure_management_interface(network_data_single, meta_data, host_moc
     )
 
 
-def test_configure_vlans(network_data_multi, meta_data, host_mock):
-    ndata = NetworkData(network_data_multi)
+def test_no_other_interfaces(network_data_single, meta_data):
+    ndata = NetworkData(network_data_single)
+    meta_data = MetaDataData(meta_data)
+    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    assert ec.other_networks == []
+
+
+def test_configure_mgmt_iface_multi_vlan(
+    network_data_multi_vlan, meta_data, host_mock, mocker
+):
+    ndata = NetworkData(network_data_multi_vlan)
     meta_data = MetaDataData(meta_data)
     ec = ESXConfig(ndata, meta_data, dry_run=False)
     ec.host = host_mock
-    ec.configure_vlans()
-    assert host_mock.portgroup_add.call_count == 3
-    assert host_mock.portgroup_set_vlan.call_count == 3
-    host_mock.portgroup_set_vlan.assert_called_with(
-        portgroup_name="internal_net_vid_444", vlan_id=444
+    nic = NIC(name="vmnic0", status="Up", link="Up", mac="14:23:f3:f5:3a:d0")
+    mocker.patch.object(ec, "identify_uplinks", return_value=[nic])
+    mgmt_pg = "Management Network"
+    mgmt_net = ndata.networks[0]
+    ec.configure_interface(ec.management_network, "vSwitch11", mgmt_pg)
+    host_mock.create_vswitch.assert_called_once_with("vSwitch11")
+    host_mock.portgroup_add.assert_called_once_with("Management Network", "vSwitch11")
+    host_mock.add_ip_interface.assert_called_once_with(
+        mgmt_net.id, mgmt_pg, mgmt_net.link.ethernet_mac_address, mgmt_net.link.mtu
     )
+    host_mock.set_static_ipv4.assert_called_once_with(
+        mgmt_net.id, mgmt_net.ip_address, mgmt_net.netmask
+    )
+
+
+def test_other_vlan_interfaces(network_data_multi_vlan, meta_data, host_mock, mocker):
+    ndata = NetworkData(network_data_multi_vlan)
+    meta_data = MetaDataData(meta_data)
+    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec.host = host_mock
+    mock_nics = [
+        NIC(name="vmnic0", status="Up", link="Up", mac="14:23:f3:f5:3a:d0"),
+        NIC(name="vmnic1", status="Up", link="Up", mac="d4:04:e6:4f:a4:d6"),
+    ]
+
+    def identify_uplinks(net):
+        if net.link.id == "tape3fbe9a7-93":
+            return [mock_nics[1]]
+        else:
+            return [mock_nics[0]]
+
+    mocker.patch.object(ec, "identify_uplinks", side_effect=identify_uplinks)
+    for network in ec.other_networks:
+        ec.configure_interface(network)
+    host_mock.create_vswitch.assert_has_calls(
+        [mocker.call("vSwitch31"), mocker.call("vSwitch32")]
+    )
+    assert host_mock.create_vswitch.call_count == 2
+    host_mock.uplink_add.assert_has_calls(
+        [
+            mocker.call(nic="vmnic0", switch_name="vSwitch31"),
+            mocker.call(nic="vmnic1", switch_name="vSwitch32"),
+        ]
+    )
+    assert host_mock.uplink_add.call_count == 2
+    host_mock.portgroup_add.assert_has_calls(
+        [
+            mocker.call("internal_net_vid_111", "vSwitch31"),
+            mocker.call("internal_net_vid_222", "vSwitch32"),
+            mocker.call("internal_net_vid_444", "vSwitch31"),
+        ]
+    )
+    assert host_mock.portgroup_add.call_count == 3
+    host_mock.portgroup_set_vlan.assert_has_calls(
+        [
+            mocker.call("internal_net_vid_111", 111),
+            mocker.call("internal_net_vid_222", 222),
+            mocker.call("internal_net_vid_444", 444),
+        ]
+    )
+    assert host_mock.portgroup_set_vlan.call_count == 3
+    host_mock.add_ip_interface.assert_has_calls(
+        [
+            mocker.call("vmk1", "internal_net_vid_111", "auto", 1450),
+            mocker.call("vmk2", "internal_net_vid_222", "auto", 1450),
+            mocker.call("vmk3", "internal_net_vid_444", "auto", 1450),
+        ]
+    )
+    assert host_mock.add_ip_interface.call_count == 3
+
+
+def test_configure_mgmt_iface_multi_phy(
+    network_data_multi_phy, meta_data, host_mock, mocker
+):
+    ndata = NetworkData(network_data_multi_phy)
+    meta_data = MetaDataData(meta_data)
+    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec.host = host_mock
+    mgmt_pg = "Management Network"
+    mgmt_net = ndata.networks[0]
+    nic = NIC(name="vmnic0", status="Up", link="Up", mac="d4:04:e6:4f:a4:d6")
+    mocker.patch.object(ec, "identify_uplinks", return_value=[nic])
+    ec.configure_interface(ec.management_network, "vSwitch11", mgmt_pg)
+    host_mock.create_vswitch.assert_called_once_with("vSwitch11")
+    host_mock.portgroup_add.assert_called_once_with("Management Network", "vSwitch11")
+    host_mock.add_ip_interface.assert_called_once_with(
+        mgmt_net.id, mgmt_pg, mgmt_net.link.ethernet_mac_address, mgmt_net.link.mtu
+    )
+    host_mock.set_static_ipv4.assert_called_once_with(
+        mgmt_net.id, mgmt_net.ip_address, mgmt_net.netmask
+    )
+
+
+def test_other_phy_interfaces(network_data_multi_phy, meta_data, host_mock, mocker):
+    ndata = NetworkData(network_data_multi_phy)
+    meta_data = MetaDataData(meta_data)
+    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec.host = host_mock
+    mock_nics = {
+        "tap-stor-100": NIC(
+            name="vmnic3", status="Up", link="Up", mac="d4:04:e6:4f:a4:d7"
+        ),
+        "tap-stor-101": NIC(
+            name="vmnic5", status="Up", link="Up", mac="14:23:f3:f6:d8:21"
+        ),
+    }
+    mocker.patch.object(
+        ec, "identify_uplinks", side_effect=lambda net: [mock_nics[net.link.id]]
+    )
+    for network in ec.other_networks:
+        ec.configure_interface(network)
+    host_mock.create_vswitch.assert_has_calls(
+        [mocker.call("vSwitch31"), mocker.call("vSwitch32")]
+    )
+    assert host_mock.create_vswitch.call_count == 2
+    host_mock.uplink_add.assert_has_calls(
+        [
+            mocker.call(nic="vmnic3", switch_name="vSwitch31"),
+            mocker.call(nic="vmnic5", switch_name="vSwitch32"),
+        ]
+    )
+    assert host_mock.uplink_add.call_count == 2
+    host_mock.portgroup_add.assert_has_calls(
+        [
+            mocker.call("tap-stor-100", "vSwitch31"),
+            mocker.call("tap-stor-101", "vSwitch32"),
+        ]
+    )
+    assert host_mock.portgroup_add.call_count == 2
+    host_mock.add_ip_interface.assert_has_calls(
+        [
+            mocker.call("vmk1", "tap-stor-100", "d4:04:e6:4f:a4:d7", 9000),
+            mocker.call("vmk2", "tap-stor-101", "14:23:f3:f6:d8:21", 9000),
+        ]
+    )
+    assert host_mock.add_ip_interface.call_count == 2
 
 
 def test_set_host_name(network_data_single, meta_data, host_mock):
@@ -80,9 +225,7 @@ def test_configure_vswitch(mocker, network_data_single, meta_data, host_mock):
         NIC(name="vmnic1", status="Up", link="Up", mac="14:23:f3:f5:21:51"),
     ]
 
-    mocker.patch.object(ec, "identify_uplinks", return_value=uplinks)
-
-    ec.configure_vswitch("vSwitch42", mtu=9000)
+    ec.configure_vswitch("vSwitch42", mtu=9000, uplinks=uplinks)
 
     host_mock.create_vswitch.assert_called_once_with("vSwitch42")
 
@@ -101,22 +244,45 @@ def test_configure_vswitch(mocker, network_data_single, meta_data, host_mock):
     host_mock.vswitch_settings.assert_called_once_with(mtu=9000, name="vSwitch42")
 
 
-def test_identify_uplinks(network_data_single, meta_data, mocker):
-    ndata = NetworkData(network_data_single)
+def test_identify_uplinks(network_data_multi_vlan, meta_data, mocker):
+    ndata = NetworkData(network_data_multi_vlan)
     meta = MetaDataData(meta_data)
 
     mocker.patch("esxi_netinit.nic_list.NICList.__init__", return_value=None)
 
     ec = ESXConfig(ndata, meta, dry_run=False)
 
-    mock_nic = NIC(name="vmnic0", status="Up", link="Up", mac="00:11:22:33:44:55")
-    ec._nics = [mock_nic]
+    mock_nics = [
+        NIC(name="vmnic0", status="Up", link="Up", mac="14:23:f3:f5:3a:d0"),
+        NIC(name="vmnic1", status="Up", link="Up", mac="d4:04:e6:4f:a4:d6"),
+    ]
+    nics = {nic.mac: nic for nic in mock_nics}
 
     mock_find_by_mac = mocker.patch.object(
-        ec.nics, "find_by_mac", return_value=mock_nic
+        ec.nics, "find_by_mac", side_effect=lambda x: nics.get(x)
     )
 
-    uplinks = ec.identify_uplinks()
+    for network in ndata.networks:
+        uplinks = ec.identify_uplinks(network)
+        if network.link.id == "tape3fbe9a7-93":
+            mock_nic = mock_nics[1]
+        else:
+            mock_nic = mock_nics[0]
+        assert uplinks == [mock_nic]
+        mock_find_by_mac.assert_called_once_with(mock_nic.mac)
+        mock_find_by_mac.reset_mock()
 
-    assert uplinks == [mock_nic]
-    mock_find_by_mac.assert_called_once_with(mock_nic.mac)
+
+def test_static_routes(network_data_multi_phy, meta_data, host_mock, mocker):
+    ndata = NetworkData(network_data_multi_phy)
+    meta_data = MetaDataData(meta_data)
+    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec.host = host_mock
+    ec.configure_static_routes()
+    host_mock.configure_static_route.assert_has_calls(
+        [
+            mocker.call("100.126.64.5", "100.127.0.0/17"),
+            mocker.call("100.126.192.5", "100.127.128.0/17"),
+        ]
+    )
+    assert host_mock.configure_static_route.call_count == 2

--- a/packages/esxi-netinit/tests/test_esxhost.py
+++ b/packages/esxi-netinit/tests/test_esxhost.py
@@ -133,3 +133,13 @@ def test_add_ip_interface(fp, esx_host):
         )
         == 1
     )
+
+
+def test_add_ip_interface_auto_mac(fp, esx_host):
+    esx_host.add_ip_interface("vmk2", "internal_vlan_20", "auto", 1450)
+    assert (
+        fp.call_count(
+            "/bin/esxcli network ip interface add --interface-name vmk2 --mtu 1450 --portgroup-name internal_vlan_20"
+        )
+        == 1
+    )

--- a/packages/esxi-netinit/tests/test_niclist.py
+++ b/packages/esxi-netinit/tests/test_niclist.py
@@ -36,3 +36,12 @@ def test_find_by_mac(sample_niclist_data):
 
     assert found.name == "vmnic2"
     assert found.mac == "d4:04:e6:50:3e:9c"
+
+
+def test_find_by_uc_mac(sample_niclist_data):
+    nics = NICList(sample_niclist_data)
+
+    found = nics.find_by_mac("d4:04:e6:50:3e:9d".upper())
+
+    assert found.name == "vmnic3"
+    assert found.mac == "d4:04:e6:50:3e:9d"


### PR DESCRIPTION
Fixes #19

This substantially reworks how the network config is created when multiple networks are present in the `network-config.json`.

Assumptions:
 - each `network` defined in the config is associated with a single `link` in the config.
 - VMware does _not_ support multi-homing in ESXi (i.e. more than one vmkernel adapter in the same subnet in the same tcp/ip stack): https://knowledge.broadcom.com/external/article/318546/multihoming-on-esxi.html
 - this implies that for a correct configuration, when multiple networks & non-vlan links are defined, they have to be separated onto separate vSwitches in order to ensure that traffic for each network traverses the correct physical uplink
 - one or more vlan links can be defined that are associated with a single non-vlan link (i.e. a physical link)
 - more than one network associated with vlan links can be associated with a single vswitch, as they can all use the same physical uplink that the vlans are attached to
 - a standard portgroup on a standard switch can only have a single vmkernel adapter
 - the way the current network config works, there is no possibility for there to be multiple physical uplinks be associated a single network
 - it may be possible for a new link `type` to be defined for ESXi that works like a `bonded` link, where there can be a virtual link defined that is associated with multiple physical links, and a network associated with the virtual link (so we should still support the possibility of multiple uplinks on a switch in the future)

How the network config now works:
 - we still create the first standard switch as `vSwitch22`, and create a portgroup on it called `mgmt`. A vmkernel adapter will be created in that portgroup, based on the first defined network in the config that has a default route defined (or the first network in the config if none of them have default routes)
 - uplink(s) for a network will be determined by which link it is attached to (either the direct physical link, or the physical link attached to a vlan link)
 - matching of mac addresses from the network config to those reported by ESXi is now done case-insensitively
 - all other networks will then have additional portgroups created for them
 - networks attached to different physical uplinks than other networks will cause new vswitches to be created (starting from `vSwitch31` and increasing the number)
 - any static routes defined for networks will be added once all vmkernel adapters have been created

Tests have been updated & added to in order to verify all of this works