### PR TITLE
Add more control over network configs

### DIFF
--- a/packages/esxi-netinit/README.md
+++ b/packages/esxi-netinit/README.md
@@ -1,1 +1,61 @@
 # ESX Networking setup scripts
+
+`esxi_netinit` is a Python program to configure network information on an ESXi
+host, and is intended to be run during the `firstboot` of ESXi after install.
+
+It will read data provided in the Openstack config-drive
+[format](https://docs.openstack.org/nova/latest/user/metadata.html#config-drives)
+and use that to configure the host.
+
+## config-drive files
+
+The files from the config-drive that are used are:
+ - `meta_data.json` (to get the supplied hostname)
+ - `network_data.json` (to get the network configuration & DNS servers)
+ - `user_data` (optional, to control what settings are applied)
+
+## What it does
+
+1. Set the device hostname (from the value supplied in `meta_data.json`)
+2. Delete the default ESXi vmkernel (`vmk0`), portgroup `Management Network` and
+  vswitch (`vswitch0`)
+3. Create a new vSwitch, portgroup and vmkernel for the management network (from
+  the data supplied in `network_data.json`)
+4. Configure the default route (from the data supplied in `network_data.json`)
+5. Configure the DNS server(s) (from the data supplied in `network_data.json`)
+6. (optionally) Configure additional vswitches, portroups & vmkernels
+  (from the data supplied in `network_data.json`)
+7. Configure any static routes (from the data supplied in `network_data.json`)
+
+The device should be rebooted after this configuration is applied
+
+## user_data settings
+
+The `user_data` file can be used to control some of the actions of the script.
+
+It is a `yaml` file, and esxi_netinit will read the following keys (default values shown):
+```yaml
+configure_all_networks: false
+management_vswitch: "vSwitch0"
+management_portgroup: "Management Portgroup"
+first_extra_vswitch_number: 1
+```
+
+The keys have the following meanings:
+
+| Key | Default | Meaning |
+|:---|:---|:---|
+| `configure_all_networks` | `false` | Whether to only configure the management network (default), or all defined networks |
+| `management_vswitch` | "vSwitch0" | Name of the vSwitch to create for the management network |
+| `management_portgroup` | "Management Portrgoup" | Name of the portgroup for the vSwitch on the management network |
+| `first_extra_vswitch_number` | 1 | vSwitches for additional networks will be numbered in sequence starting from this value |
+
+Note that vmkernel nics will be created strictly in sequence `vmk0`, `vmk1`, etc.
+
+The default behaviour of the code is to create a single vSwitch, portgroup and vmkernel with the same
+names that the ESXi installer gives them - this is because other VMware tooling may expect
+new hypervisor hosts to be configured in this way (e.g. for enrolling into VCF).
+
+However, if your use-case allows for additional network configuration to be applied to
+the host during provisioning, setting `configure_all_networks: true` will allow
+esxi_netinit to do that for you.

--- a/packages/esxi-netinit/esxi_netinit/configdata.py
+++ b/packages/esxi-netinit/esxi_netinit/configdata.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+
+from esxi_netinit.defaults import DEFAULT_PORTGROUP, DEFAULT_VSWITCH
+
+@dataclass
+class ConfigData:
+    configure_all_networks: bool = False
+    management_vswitch: str = DEFAULT_VSWITCH
+    management_portgroup: str = DEFAULT_PORTGROUP
+    first_extra_vswitch_number: int = 1
+
+    def __post_init__(self):
+        if self.first_extra_vswitch_number < 0:
+            raise ValueError("first_extra_vswitch_number must be positive")

--- a/packages/esxi-netinit/esxi_netinit/configdata.py
+++ b/packages/esxi-netinit/esxi_netinit/configdata.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
-from esxi_netinit.defaults import DEFAULT_PORTGROUP, DEFAULT_VSWITCH
+from esxi_netinit.defaults import DEFAULT_PORTGROUP
+from esxi_netinit.defaults import DEFAULT_VSWITCH
+
 
 @dataclass
 class ConfigData:
@@ -10,5 +12,6 @@ class ConfigData:
     first_extra_vswitch_number: int = 1
 
     def __post_init__(self):
+        """Pointless comment to appease the linter."""
         if self.first_extra_vswitch_number < 0:
             raise ValueError("first_extra_vswitch_number must be positive")

--- a/packages/esxi-netinit/esxi_netinit/defaults.py
+++ b/packages/esxi-netinit/esxi_netinit/defaults.py
@@ -1,0 +1,2 @@
+DEFAULT_VSWITCH = "vSwitch0"
+DEFAULT_PORTGROUP = "Management Network"

--- a/packages/esxi-netinit/esxi_netinit/esxconfig.py
+++ b/packages/esxi-netinit/esxi_netinit/esxconfig.py
@@ -14,14 +14,19 @@ logger = logging.getLogger(__name__)
 
 class ESXConfig:
     def __init__(
-        self, network_data: NetworkData, meta_data: MetaDataData, dry_run=False
+        self,
+        network_data: NetworkData,
+        meta_data: MetaDataData,
+        first_extra_vswitch_number: int,
+        dry_run=False,
     ) -> None:
         self.network_data = network_data
         self.meta_data = meta_data
         self.dry_run = dry_run
         self.host = ESXHost(dry_run)
         self.uplink_map = {}
-        self.next_switch_number = 31
+        self.vswitches = set()
+        self.next_switch_number = first_extra_vswitch_number
 
     def configure_hostname(self):
         self.host.set_hostname(self.meta_data.metadata.hostname)
@@ -50,8 +55,10 @@ class ESXConfig:
                 self.host.configure_static_route(route.gateway, route_net.compressed)
 
     def get_next_vswitch(self):
-        switch_name = f"vSwitch{self.next_switch_number}"
-        self.next_switch_number += 1
+        switch_name = None
+        while not switch_name or switch_name in self.vswitches:
+            switch_name = f"vSwitch{self.next_switch_number}"
+            self.next_switch_number += 1
         return switch_name
 
     def configure_interface(self, net: Network, switch_name=None, portgroup_name=None):
@@ -103,6 +110,7 @@ class ESXConfig:
 
         self.host.vswitch_security(name=switch_name)
         self.host.vswitch_settings(mtu=mtu, name=switch_name)
+        self.vswitches.add(switch_name)
 
     def configure_requested_dns(self):
         """Configures DNS servers that were provided in network_data.json."""

--- a/packages/esxi-netinit/esxi_netinit/main.py
+++ b/packages/esxi-netinit/esxi_netinit/main.py
@@ -5,15 +5,11 @@ import os
 import sys
 from pathlib import Path
 
+from esxi_netinit.defaults import DEFAULT_PORTGROUP, DEFAULT_VSWITCH
 from esxi_netinit.esxconfig import ESXConfig
 from esxi_netinit.meta_data import MetaDataData
 from esxi_netinit.network_data import NetworkData
-
-OLD_MGMT_PG = "Management Network"
-OLD_VSWITCH = "vSwitch0"
-NEW_MGMT_PG = "mgmt"
-NEW_VSWITCH = "vSwitch22"
-
+from esxi_netinit.user_data import UserData
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +40,7 @@ def main(config_dir, dry_run):
     config_path = Path(config_dir)
     network_data_file = config_path / "network_data.json"
     meta_data_file = config_path / "meta_data.json"
+    user_data_file = config_path / "user_data"
 
     if not network_data_file.exists():
         logger.error("Missing network_data.json in %s", config_dir)
@@ -55,19 +52,31 @@ def main(config_dir, dry_run):
 
     network_data = NetworkData.from_json_file(network_data_file)
     meta_data = MetaDataData.from_json_file(meta_data_file)
+    if user_data_file.exists():
+        config_data = UserData.from_yaml_file(user_data_file).configdata
+    else:
+        config_data = UserData(dict()).configdata
 
-    esx = ESXConfig(network_data, meta_data, dry_run=dry_run)
+    esx = ESXConfig(
+        network_data, meta_data, config_data.first_extra_vswitch_number, dry_run=dry_run
+    )
     esx.configure_hostname()
-    esx.clean_default_network_setup(OLD_MGMT_PG, OLD_VSWITCH)
+    esx.clean_default_network_setup(DEFAULT_PORTGROUP, DEFAULT_VSWITCH)
 
     # this configures the Management Network to the default vSwitch
-    esx.configure_interface(esx.management_network, NEW_VSWITCH, NEW_MGMT_PG)
+    esx.configure_interface(
+        esx.management_network,
+        config_data.management_vswitch,
+        config_data.management_portgroup,
+    )
     esx.configure_default_route()
     esx.configure_requested_dns()
 
     # this configures the remaining networks, adding more vSwitches as necessary
-    for net in esx.other_networks:
-        esx.configure_interface(net)
+    # only occurs if userdata file with 'configure_all_networks: true' is present
+    if config_data.configure_all_networks:
+        for net in esx.other_networks:
+            esx.configure_interface(net)
 
     # Finally add any static routes
     esx.configure_static_routes()
@@ -78,7 +87,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "config_dir",
         help="Path to the configuration dir containing "
-        "network_data.json, meta_data.json",
+        "network_data.json, meta_data.json and user_data",
     )
     parser.add_argument(
         "--dry-run",

--- a/packages/esxi-netinit/esxi_netinit/main.py
+++ b/packages/esxi-netinit/esxi_netinit/main.py
@@ -5,7 +5,8 @@ import os
 import sys
 from pathlib import Path
 
-from esxi_netinit.defaults import DEFAULT_PORTGROUP, DEFAULT_VSWITCH
+from esxi_netinit.defaults import DEFAULT_PORTGROUP
+from esxi_netinit.defaults import DEFAULT_VSWITCH
 from esxi_netinit.esxconfig import ESXConfig
 from esxi_netinit.meta_data import MetaDataData
 from esxi_netinit.network_data import NetworkData

--- a/packages/esxi-netinit/esxi_netinit/user_data.py
+++ b/packages/esxi-netinit/esxi_netinit/user_data.py
@@ -1,0 +1,24 @@
+
+import logging
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from esxi_netinit.configdata import ConfigData
+
+logger = logging.getLogger(__name__)
+
+class UserData:
+    """Represents user_data."""
+
+    def __init__(self, data: dict) -> None:
+        self.configdata = ConfigData(**data)
+
+    @staticmethod
+    def from_yaml_file(path) -> "UserData":
+        data = dict()
+        if yaml:
+            with open(path) as f:
+                data.update(yaml.safe_load(f))
+        return UserData(data)

--- a/packages/esxi-netinit/esxi_netinit/user_data.py
+++ b/packages/esxi-netinit/esxi_netinit/user_data.py
@@ -1,5 +1,5 @@
-
 import logging
+
 try:
     import yaml
 except ImportError:
@@ -8,6 +8,7 @@ except ImportError:
 from esxi_netinit.configdata import ConfigData
 
 logger = logging.getLogger(__name__)
+
 
 class UserData:
     """Represents user_data."""

--- a/packages/esxi-netinit/tests/test_esxconfig.py
+++ b/packages/esxi-netinit/tests/test_esxconfig.py
@@ -287,6 +287,7 @@ def test_static_routes(network_data_multi_phy, meta_data, host_mock, mocker):
     )
     assert host_mock.configure_static_route.call_count == 2
 
+
 def test_get_next_vswitch(host_mock, network_data_single, meta_data):
     ndata = NetworkData(network_data_single)
     meta_data = MetaDataData(meta_data)

--- a/packages/esxi-netinit/tests/test_esxconfig.py
+++ b/packages/esxi-netinit/tests/test_esxconfig.py
@@ -15,7 +15,7 @@ def host_mock(mocker):
 def test_configure_requested_dns(host_mock, network_data_single, meta_data):
     ndata = NetworkData(network_data_single)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 1, dry_run=False)
     ec.host = host_mock
     ec.configure_requested_dns()
     print(host_mock.configure_dns.call_args_list)
@@ -25,7 +25,7 @@ def test_configure_requested_dns(host_mock, network_data_single, meta_data):
 def test_configure_default_route(network_data_single, meta_data, host_mock):
     ndata = NetworkData(network_data_single)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 1, dry_run=False)
     ec.host = host_mock
     ec.configure_default_route()
     host_mock.configure_static_route.assert_called_once_with("192.168.1.1", "default")
@@ -36,7 +36,7 @@ def test_configure_management_interface(
 ):
     ndata = NetworkData(network_data_single)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 21, dry_run=False)
     ec.host = host_mock
     nic = NIC(name="vmnic0", status="Up", link="Up", mac="14:23:f3:f5:3a:d0")
     mocker.patch.object(ec, "identify_uplinks", return_value=[nic])
@@ -56,7 +56,7 @@ def test_configure_management_interface(
 def test_no_other_interfaces(network_data_single, meta_data):
     ndata = NetworkData(network_data_single)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 1, dry_run=False)
     assert ec.other_networks == []
 
 
@@ -65,7 +65,7 @@ def test_configure_mgmt_iface_multi_vlan(
 ):
     ndata = NetworkData(network_data_multi_vlan)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 21, dry_run=False)
     ec.host = host_mock
     nic = NIC(name="vmnic0", status="Up", link="Up", mac="14:23:f3:f5:3a:d0")
     mocker.patch.object(ec, "identify_uplinks", return_value=[nic])
@@ -85,7 +85,7 @@ def test_configure_mgmt_iface_multi_vlan(
 def test_other_vlan_interfaces(network_data_multi_vlan, meta_data, host_mock, mocker):
     ndata = NetworkData(network_data_multi_vlan)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 31, dry_run=False)
     ec.host = host_mock
     mock_nics = [
         NIC(name="vmnic0", status="Up", link="Up", mac="14:23:f3:f5:3a:d0"),
@@ -143,7 +143,7 @@ def test_configure_mgmt_iface_multi_phy(
 ):
     ndata = NetworkData(network_data_multi_phy)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 21, dry_run=False)
     ec.host = host_mock
     mgmt_pg = "Management Network"
     mgmt_net = ndata.networks[0]
@@ -163,7 +163,7 @@ def test_configure_mgmt_iface_multi_phy(
 def test_other_phy_interfaces(network_data_multi_phy, meta_data, host_mock, mocker):
     ndata = NetworkData(network_data_multi_phy)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 11, dry_run=False)
     ec.host = host_mock
     mock_nics = {
         "tap-stor-100": NIC(
@@ -179,20 +179,20 @@ def test_other_phy_interfaces(network_data_multi_phy, meta_data, host_mock, mock
     for network in ec.other_networks:
         ec.configure_interface(network)
     host_mock.create_vswitch.assert_has_calls(
-        [mocker.call("vSwitch31"), mocker.call("vSwitch32")]
+        [mocker.call("vSwitch11"), mocker.call("vSwitch12")]
     )
     assert host_mock.create_vswitch.call_count == 2
     host_mock.uplink_add.assert_has_calls(
         [
-            mocker.call(nic="vmnic3", switch_name="vSwitch31"),
-            mocker.call(nic="vmnic5", switch_name="vSwitch32"),
+            mocker.call(nic="vmnic3", switch_name="vSwitch11"),
+            mocker.call(nic="vmnic5", switch_name="vSwitch12"),
         ]
     )
     assert host_mock.uplink_add.call_count == 2
     host_mock.portgroup_add.assert_has_calls(
         [
-            mocker.call("tap-stor-100", "vSwitch31"),
-            mocker.call("tap-stor-101", "vSwitch32"),
+            mocker.call("tap-stor-100", "vSwitch11"),
+            mocker.call("tap-stor-101", "vSwitch12"),
         ]
     )
     assert host_mock.portgroup_add.call_count == 2
@@ -208,7 +208,7 @@ def test_other_phy_interfaces(network_data_multi_phy, meta_data, host_mock, mock
 def test_set_host_name(network_data_single, meta_data, host_mock):
     ndata = NetworkData(network_data_single)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 1, dry_run=False)
     ec.host = host_mock
     ec.configure_hostname()
     host_mock.set_hostname.assert_called_once_with("test.novalocal")
@@ -217,7 +217,7 @@ def test_set_host_name(network_data_single, meta_data, host_mock):
 def test_configure_vswitch(mocker, network_data_single, meta_data, host_mock):
     ndata = NetworkData(network_data_single)
     meta = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta, dry_run=False)
+    ec = ESXConfig(ndata, meta, 1, dry_run=False)
     ec.host = host_mock
 
     uplinks = [
@@ -250,7 +250,7 @@ def test_identify_uplinks(network_data_multi_vlan, meta_data, mocker):
 
     mocker.patch("esxi_netinit.nic_list.NICList.__init__", return_value=None)
 
-    ec = ESXConfig(ndata, meta, dry_run=False)
+    ec = ESXConfig(ndata, meta, 1, dry_run=False)
 
     mock_nics = [
         NIC(name="vmnic0", status="Up", link="Up", mac="14:23:f3:f5:3a:d0"),
@@ -276,7 +276,7 @@ def test_identify_uplinks(network_data_multi_vlan, meta_data, mocker):
 def test_static_routes(network_data_multi_phy, meta_data, host_mock, mocker):
     ndata = NetworkData(network_data_multi_phy)
     meta_data = MetaDataData(meta_data)
-    ec = ESXConfig(ndata, meta_data, dry_run=False)
+    ec = ESXConfig(ndata, meta_data, 1, dry_run=False)
     ec.host = host_mock
     ec.configure_static_routes()
     host_mock.configure_static_route.assert_has_calls(
@@ -286,3 +286,15 @@ def test_static_routes(network_data_multi_phy, meta_data, host_mock, mocker):
         ]
     )
     assert host_mock.configure_static_route.call_count == 2
+
+def test_get_next_vswitch(host_mock, network_data_single, meta_data):
+    ndata = NetworkData(network_data_single)
+    meta_data = MetaDataData(meta_data)
+    ec = ESXConfig(ndata, meta_data, 31, dry_run=False)
+    ec.host = host_mock
+    assert ec.get_next_vswitch() == "vSwitch31"
+    assert ec.get_next_vswitch() == "vSwitch32"
+    ec.vswitches.add("vSwitch31")
+    ec.vswitches.add("vSwitch32")
+    ec.vswitches.add("vSwitch33")
+    assert ec.get_next_vswitch() == "vSwitch34"

--- a/src/esxi_img/data/firstboot/98-reboot.sh
+++ b/src/esxi_img/data/firstboot/98-reboot.sh
@@ -1,3 +1,6 @@
+/sbin/backup.sh 1
 logger -s -t esxi-netinit "Triggering reboot in 20 seconds"
 /bin/loadESXEnable -e && /usr/lib/vmware/loadesx/bin/loadESX.py || true
+esxcli system maintenanceMode set --enable true
+cp -pf /var/log/kickstart.log /scratch/log/kickstart.log.0
 esxcli system shutdown reboot -d 20 -r "rebooting ESXi after host config"


### PR DESCRIPTION
Following the experience of using images created for newer versions of VCF, this PR introduces more control over the network setup that the esxi_netinit python code will generate.

It makes the following changes:
 - default to only creating single vSwitch, portgroup & vmkernel, using the default VMware names for those items (gives out of the box compatibility with VCF 9)
 - allow extra configuration to be controlled via userdata (whether to create additional network config & custom names for the management network items)

It also fixes a bug where the ESXi kickstart config was intended to reboot the host after executing the esxi_netinit code, but failed to do so (which leaves hosts in a state where when they are subsequently rebooted, they lose all network config)
