### PR TITLE
Add firstboot script to regen ssl cert after possible hostname change

### DIFF
--- a/src/esxi_img/data/firstboot/50-ssl-cert.sh
+++ b/src/esxi_img/data/firstboot/50-ssl-cert.sh
@@ -1,0 +1,1 @@
+/sbin/generate-certificates


### PR DESCRIPTION
As the python esxi_netinit scripts may set the hostname of the server during first boot, this adds a script to run after that change to regenerate the host SSL certificate so that it matches the new hostname.
